### PR TITLE
Inherit Jekyll's rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,28 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 2.1
+  Exclude:
+    - vendor/**/*
+
+Metrics/AbcSize:
+  Exclude:
+    - lib/jekyll/srcset/tag.rb
+
+Metrics/LineLength:
+  Exclude:
+    - lib/jekyll/srcset/tag.rb
+    - jekyll-srcset.gemspec
+
+Metrics/MethodLength:
+  Exclude:
+    - lib/jekyll/srcset/tag.rb
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - lib/jekyll/srcset/tag.rb
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - lib/jekyll/srcset/tag.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in jekyll-srcset.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,3 @@
-require "bundler/gem_tasks"
+# frozen_string_literal: true
 
+require "bundler/gem_tasks"

--- a/jekyll-srcset.gemspec
+++ b/jekyll-srcset.gemspec
@@ -1,32 +1,35 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll/srcset/version'
+require "jekyll/srcset/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-srcset"
   spec.version       = Jekyll::Srcset::VERSION
   spec.authors       = ["Mathias Biilmann Christensen"]
   spec.email         = ["info@mathias-biilmann.net"]
-  spec.summary       = %q{This Jekyll plugin ads an image_tag that will generate responsive img tags}
-  spec.description   = %q{
+  spec.summary       = "This Jekyll plugin ads an image_tag that will generate responsive img tags"
+  spec.description   = %q(
   This Jekyll plugin makes it very easy to send larger images to devices with high pixel densities.
 
   The plugin adds an `image_tag` Liquid tag that can be used like this:
 
   \{% image_tag src="/image.png" width="100" %\}
-}
+)
   spec.homepage      = "https://github.com/netlify/jekyll-srcset"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rmagick"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_runtime_dependency 'jekyll', '> 2'
+  spec.add_development_dependency "rubocop", "~> 0.5"
+  spec.add_runtime_dependency "jekyll", "> 2"
 end

--- a/lib/jekyll-srcset.rb
+++ b/lib/jekyll-srcset.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "jekyll/srcset"
 
-Liquid::Template.register_tag('image_tag', Jekyll::SrcsetTag)
+Liquid::Template.register_tag("image_tag", Jekyll::SrcsetTag)

--- a/lib/jekyll/srcset.rb
+++ b/lib/jekyll/srcset.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "jekyll/srcset/version"
 require "jekyll/srcset/tag"
 require "jekyll"

--- a/lib/jekyll/srcset/version.rb
+++ b/lib/jekyll/srcset/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Jekyll
   module Srcset
-    VERSION = "0.1.3"
+    VERSION = "0.1.3".freeze
   end
 end


### PR DESCRIPTION
👋  @biilmann 

This PR is the result of applying Jekyll Ruby Style Guide to this plugin and fixing offenses with Rubocop's auto-correct (`rubocop -a`).

This isn't intended to modify the current behavior, but as there's no test coverage, it would be wiser to test this branch on an existing site using this plugin 😄 
