### PR TITLE
Replaced "gems:" with "plugins:"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or install it yourself as:
 Then add the gem to your Jekyll `_config.yml`:
 
 ```yml
-gems:
+plugins:
   - jekyll-srcset
 ```
 


### PR DESCRIPTION
According to a warning I got, "gems:" has been depreciated and replaced with "plugins:", so I made that change in the README.

Sorry if this is incorrect, I haven't made many pull requests before.